### PR TITLE
chore: improvements to dev xp

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -5,6 +5,6 @@ module.exports = {
   ],
   plugins: ["prettier"], // This enables eslint-plugin-prettier. Sets up rules to run prettier as an eslint rule.
   rules: {
-    "prettier/prettier": "error", // This will display prettier errors as ESLint errors. The 'error' severity means that these errors will cause your build to fail. You can change this to 'warn' if you prefer.
+    "prettier/prettier": ["error", { endOfLine: "auto" }], // This will display prettier errors as ESLint errors. The 'error' severity means that these errors will cause your build to fail. You can change this to 'warn' if you prefer.
   },
 };


### PR DESCRIPTION
Fixes linting errors reported by _ESLint_ arising due to _Prettier_ checking code formatting based on a fixed default EOL character (LF).
The default EOL character can be different on different operating systems (e.g.:- CRLF on Windows). This can cause _Prettier_ to show errors on each EOL character. 
Currently, we use _ESLint_ as the default formatter with _Prettier_ configured as a plugin in it, to report formatting issues as linting 
errors. I've kept that architecture same, and added a _Prettier_ rule that checks formatting based on the default EOL character on any machine. Configuration options can be found in the _Prettier_ [docs](https://prettier.io/docs/options#end-of-line).

## Screenshot of the Error
![Screenshot 2025-02-26 185354](https://github.com/user-attachments/assets/b6f8a8c2-2a56-4966-8e45-77f3fca3f313)
