### PR TITLE
feat: facilitate MongoDB connection from dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "forwardPorts": [
         8001,
         3000,
-        27018
+        27017
     ],
     "customizations": {
         "vscode": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,6 +11,9 @@ services:
       - ..:/workspace
     ports:
       - "8001:8001"
+    environment:
+      - MONGO_HOST=mongodb
+      - MONGO_PORT=27017
     depends_on:
       - mongodb
 


### PR DESCRIPTION
Facilitates MongoDB connection from inside the Dev Container.

## Changes
- Fixed port forwarding in `devcontainer.json`.
- Added the `MONGO_HOST` and `MONGO_PORT` env variables to make the development of an environment flexible connection approach easier.
- Updated `README.md` to include detailed documentation and background about the MongoDB connection.
