### PR TITLE
(chore):  include Django REST framework in requirements and set up Ruff linter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
-      "dbaeumer.vscode-eslint"
+      "dbaeumer.vscode-eslint",
+      "charliermarsh.ruff"
     ]
 }
   

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,4 +10,7 @@
     "[jsonc]": {
         "editor.defaultFormatter": "vscode.json-language-features"
     },
+    "[python]":{
+        "editor.defaultFormatter": "charliermarsh.ruff"
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Interneers Lab
 
 Welcome to the **Interneers Lab 2025** repository! This serves as a minimal starter kit for learning and experimenting with:
+
 - **Django** (Python)
-- **React**  (with TypeScript)
+- **React** (with TypeScript)
 - **MongoDB** (via Docker Compose)
 - Development environment in **VSCode** (recommended)
 
 **Important:** Use the **same email** you shared during onboarding when configuring Git and related tools. That ensures consistency across all internal systems.
-
 
 ---
 
@@ -26,12 +26,13 @@ Welcome to the **Interneers Lab 2025** repository! This serves as a minimal star
    - [Pushing Your First Change](#pushing-your-first-change)
 7. [Making your first change and running it](#making-your-first-change)
    - [Backend](#backend)
-      - [Starter 0](#starter-0-changes)
-      - [Starter 1](#starter-1-changes)
+     - [Starter 0](#starter-0-changes)
+     - [Starter 1](#starter-1-changes)
 8. [Running Tests (Optional)](#running-tests-optional)
 9. [Frontend Setup](#frontend-setup)
 10. [Dev Container Usage](#dev-container-usage)
-11. [Further Reading](#further-reading)
+11. [Linter Usage](#linter-usage)
+12. [Further Reading](#further-reading)
 
 ---
 
@@ -40,6 +41,7 @@ Welcome to the **Interneers Lab 2025** repository! This serves as a minimal star
 ### 1. Setting up Git and the Repo
 
 1. **Install Git** (if not already):
+
    - **macOS**: [Homebrew](https://brew.sh/) users can run `brew install git`.
    - **Windows**: Use [Git for Windows](https://gitforwindows.org/).
    - **Linux**: Install via your distro’s package manager, e.g., `sudo apt-get install git` (Ubuntu/Debian).
@@ -48,16 +50,17 @@ Welcome to the **Interneers Lab 2025** repository! This serves as a minimal star
    ```bash
    git config --global user.name "Your Name"
    git config --global user.email "your.email@example.com" # Use the same email you shared during onboarding
+   ```
 3. What is Forking?
 
    Forking a repository on GitHub creates your own copy under your GitHub account, where you can make changes independently without affecting the original repo. Later, you can make pull requests to merge changes back if needed.
 
 4. Fork the Rippling/interneers-lab repository (ensure you’re in the correct org or your personal GitHub account, as directed).
 5. **Clone** your forked repo:
-    ```
-    git clone git@github.com:<YourUsername>/interneers-lab.git
-    cd interneers-lab
-    ```
+   ```
+   git clone git@github.com:<YourUsername>/interneers-lab.git
+   cd interneers-lab
+   ```
 
 ## Prerequisites & Tooling
 
@@ -65,30 +68,38 @@ These are the essential tools you need:
 
 1. **Homebrew (macOS Only)**
 
-   **Why?** 
-   
+   **Why?**
+
    Homebrew is a popular package manager for macOS, making it easy to install and update software (like Python, Node, Yarn, etc.).
-   
-   **Install**:  
+
+   **Install**:
+
    ```bash
    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
+   ```
+
 2. **Python 3.13** (if you need Python scripts or a backend environment)
+
    - **Why 3.13?**
 
-      This is the recommended version for the module’s Python-related tasks, ensuring consistency across projects.
-   - **Install or Upgrade**:  
-     
-     - macOS (with Homebrew): `brew install python`  
-     - Windows: [Download from python.org](https://www.python.org/downloads/) (ensure it’s 3.13)  
+     This is the recommended version for the module’s Python-related tasks, ensuring consistency across projects.
+
+   - **Install or Upgrade**:
+
+     - macOS (with Homebrew): `brew install python`
+     - Windows: [Download from python.org](https://www.python.org/downloads/) (ensure it’s 3.13)
+
    - **Verify**:
-     
+
      ```bash
      python3 --version
      ```
+
      You should see something like `Python 3.13.x`.
 
    If you are getting something else , please update `.bashrc` or `.zshrc` to have alias with following
+
    ```
    vim ~/.zshrc   # or any preferred editor of your choice
    alias python3 = "/opt/homebrew/bin/python3.13"
@@ -96,47 +107,48 @@ These are the essential tools you need:
    source ~/.zshrc # or ~/.bashrc
    ```
 
-3. **virtualenv** or built-in `venv`  
+3. **virtualenv** or built-in `venv`
 
    **Why?**
-   
+
    A virtual environment keeps project dependencies isolated from your system Python.
 
    **Install**
-   - `pip3 install virtualenv` (if needed)  
+
+   - `pip3 install virtualenv` (if needed)
    - or use `python3 -m venv venv`
 
    **Tutorial**
    Refer to the [Virtualenv Tutorial](https://www.youtube.com/watch?v=eDe-z2Qy9x4) to learn more about why virtual environments matter.
 
    **Verify**
-   
+
    - Try to activate the venv using the following command
-      ```
-      source venv/bin/activate         # macOS/Linux
-      .\venv\Scripts\activate          # Windows
-      ```
+
+     ```
+     source venv/bin/activate         # macOS/Linux
+     .\venv\Scripts\activate          # Windows
+     ```
 
    - In most of the machines, your terminal prompt will be prefixed with something like (venv) (or whatever you named the virtual environment).
 
-      ![alt text](image.png)
+     ![alt text](image.png)
 
    Check Which Python Is Being Used:
 
    1. macOS/Linux
-      
-      ```which python```
+
+      `which python`
 
       This should return a path inside the venv/ directory (e.g., .../my-project/venv/bin/python
-   
+
    2. Windows
 
-      ```where python```
+      `where python`
 
       This should return a path inside `venv\Scripts\python.exe`.
-   
 
-4. **Docker** & **Docker Compose**  
+4. **Docker** & **Docker Compose**
 
    **Why**
 
@@ -144,30 +156,30 @@ These are the essential tools you need:
 
    **Install**
 
-   - [Docker Desktop for Mac](https://www.docker.com/products/docker-desktop/)  
-   - [Docker Desktop for Windows](https://www.docker.com/products/docker-desktop/)  
-   
+   - [Docker Desktop for Mac](https://www.docker.com/products/docker-desktop/)
+   - [Docker Desktop for Windows](https://www.docker.com/products/docker-desktop/)
+
    **Verify**
-   
+
    Verify verison and successfull installation with `docker --version` and `docker compose version`
 
+5. **Node.js** & **Yarn**
 
-5. **Node.js** & **Yarn**  
-   
    **Why?**
 
    We use React.js for our frontend, which requires Node.js. Yarn is a popular package manager for Node.
 
    **Install**
 
-   - [Node.js Downloads](https://nodejs.org/en/download/)  
-   - [Yarn Install Docs](https://classic.yarnpkg.com/lang/en/docs/install/)  
+   - [Node.js Downloads](https://nodejs.org/en/download/)
+   - [Yarn Install Docs](https://classic.yarnpkg.com/lang/en/docs/install/)
 
    **Verify**
-   - Check version and installation completion with `node --version` and `yarn --version` 
 
-6. **API & MongoDB Tools**  
-   - **[Postman](https://www.postman.com/downloads/)**, **[Insomnia](https://insomnia.rest/download)**, or **[Paw](https://paw.cloud/client) (only for mac)** for API testing  
+   - Check version and installation completion with `node --version` and `yarn --version`
+
+6. **API & MongoDB Tools**
+   - **[Postman](https://www.postman.com/downloads/)**, **[Insomnia](https://insomnia.rest/download)**, or **[Paw](https://paw.cloud/client) (only for mac)** for API testing
    - **[MongoDB Compass](https://www.mongodb.com/try/download/compass)** or a **[VSCode MongoDB](https://code.visualstudio.com/docs/azure/mongodb)** extension
 
 ## Setting Up the Project
@@ -175,15 +187,19 @@ These are the essential tools you need:
 ### Create a Python Virtual Environment
 
 The python virtual env should be created inside the backend directory. Run the following commands inside the `backend` directory to create virtual environment.
+
 ```bash
 cd backend
 python3.13 -m venv venv
 ```
+
 To activate the virtual environment, run the following command:
+
 ```bash
 # macOS/Linux
 source venv/bin/activate
 ```
+
 ```Powershell
 # on Windows Powershell:
 Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
@@ -197,9 +213,10 @@ pip3 install -r requirements.txt
 ```
 
 By default, **requirements.txt** includes:
+
 - **Django**
 - **pymongo** (MongoDB driver)
-
+- **djangorestframework**
 
 **Check your `.gitignore`**  
 Make sure `venv/` and other temporary files aren’t committed.
@@ -277,13 +294,14 @@ Confirm that all meet any minimum version requirements.
 - **Docker**  
   Allows you to visualize, manage, and interact with Docker containers and images directly in VSCode.
 
-- *(Optional)* **MongoDB for VSCode**  
+- _(Optional)_ **MongoDB for VSCode**  
   Lets you connect to and browse your MongoDB databases, run queries, and view results without leaving VSCode.
 
-- *(Optional)* **Dev Containers**  
+- _(Optional)_ **Dev Containers**  
   Helps you develop and test the project inside a Dev Container.
 
 ---
+
 ### Making your first change
 
 ## Backend:
@@ -323,13 +341,15 @@ def hello_name(request):
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('hello/', hello_name), 
+    path('hello/', hello_name),
     # Example usage: /hello/?name=Bob
     # returns {"message": "Hello, Bob!"}
 ]
 
 ```
+
 ---
+
 #### 2. Run the Django Server
 
 Activate your virtual environment (if not already active):
@@ -340,16 +360,20 @@ source venv/bin/activate         # macOS/Linux
 ```
 
 Install dependencies (if you haven't):
+
 ```bash
 cd backend  # if you are not inside  /backend already.
 pip3 install -r requirements.txt
 ```
+
 Navigate to your Django project folder (e.g., cd backend) and run the server on port 8001:
+
 ```
 python manage.py runserver 8001
 ```
 
 You should see:
+
 ```
 Starting development server at http://127.0.0.1:8001/
 ```
@@ -361,18 +385,20 @@ Install a REST client like Postman (if you haven’t already).
 Create a new GET request.
 
 Enter the endpoint, for example:
+
 ```
 http://127.0.0.1:8001/hello/?name=Bob
 ```
 
 Send the request. You should see a JSON response:
+
 ```
 {
   "message": "Hello, Bob!"
 }
 ```
 
-#### Congratulations! you wrote your first own API. 
+#### Congratulations! you wrote your first own API.
 
 ---
 
@@ -382,10 +408,11 @@ Send the request. You should see a JSON response:
    ```bash
    git add .
    git commit -m "Your descriptive commit message"
+   ```
 2. **Push to your forked repo (main branch by default):**
-    ```
-    git push origin main
-    ```
+   ```
+   git push origin main
+   ```
 
 ---
 
@@ -399,9 +426,11 @@ python manage.py test
 ```
 
 ### Docker
+
 ```
 docker compose ps
 ```
+
 Note: This command displays the status of the containers, including whether they are running, their assigned ports, and their names, as defined in the docker-compose.yaml file. If you have set up a MongoDB server using Docker and connected it to your Django application, you can use this command to verify that the MongoDB container is running properly.
 
 ---
@@ -416,11 +445,13 @@ Head over to the frontend README to check it out:
 ---
 
 ## Dev Container Usage
+
 Opening this repository in VSCode, GitHub Codespaces or any other supported editor/IDE would allow the repository to be opened in a [dev container](https://containers.dev/).
 
 The Dev Container contains all the necessary dependencies to build, run and test all the components of the project.
 
 ### Developing from within the Container
+
 Ensure that you have the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension activated.
 
 Follow these steps to develop the project from within the Dev Container:
@@ -438,14 +469,17 @@ Follow these steps to develop the project from within the Dev Container:
 Once the Dev Container is up and running, the following services will be available:
 
 #### Backend
+
 - **Port:** `8001`
 - **URL:** [http://localhost:8001](http://localhost:8001)
 
 #### Frontend
+
 - **Port:** `3000`
 - **URL:** [http://localhost:3000](http://localhost:3000)
 
 #### MongoDB
+
 - **Port:** `27018`
 - **URL:** [http://localhost:27018](http://localhost:27018)
 
@@ -454,12 +488,15 @@ Follow the respective URLs to access the services.
 You can then work on the project as usual within the development container. Any changes you make will be automatically reflected in the local file system as well as in the running services (backend, frontend, etc.) through hot reloading.
 
 #### Note:
+
 Always keep `backend/requirements.txt` updated with any new python dependencies you use, as the Dev Container relies on it to set up the environment.
 
 ### Hot Reloading
+
 A quick demonstration of hot reloading in action after making changes can be found [here](https://drive.google.com/file/d/1wgNInfN2DLP7yG4mmJCZhhALhd6pw0TO/view?usp=drive_link).
 
 ### MongoDB Connection
+
 MongoDB connections differ when running the project inside a Dev Container compared to running it locally:
 
 1. **Container Networking Differences** - When running inside a Dev Container, services communicate over Docker's internal network. The hostname must be set to the service name (i.e., `mongodb`) instead of `localhost`, as `localhost` would refer to the container itself, not the MongoDB service.
@@ -477,6 +514,7 @@ To ensure flexibility in all environments, the `backend` service provides two **
 These variables can be utilized to enable a dynamic connection approach, ensuring seamless adaptability across different environments:
 
 #### Example `settings.py` (Django + mongoengine):
+
 ```python
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
@@ -501,6 +539,12 @@ connect(
 DATABASES = {}
 ```
 
+## Linter Usage
+
+- Code is automatically formatted on saving(`Ctrl + S`)
+- Formatting imports needs to be manually done from Command Palette (`Ctrl + Shift + P`)
+- Use `Ruff: Fix all auto-fixable problems` via Command Palette to runs lint checks and automatically fix any fixable issues
+
 ## Further Reading
 
 - Django: https://docs.djangoproject.com/en/3.2/
@@ -511,15 +555,9 @@ DATABASES = {}
 
 ---
 
-
 ## Important Note on `settings.py`:
+
 - You should commit settings.py so the Django configuration is shared.
 - However, never commit secrets (API keys, passwords) directly. Use environment variables or .env files (excluded via .gitignore).
 
 ---
-
-
-
-
-
-

--- a/backend/django_app/settings.py
+++ b/backend/django_app/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "rest_framework",
 ]
 
 MIDDLEWARE = [

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 Django==5.1.6
 pymongo==4.11.1
+djangorestframework==3.15.2


### PR DESCRIPTION
### Overview
We need the Django REST framework for Week-2 tasks(involving building REST APIs). 
Code formatter and linter support was missing for python/backend. Ruff is the recommended Python formatter/linter.

### Changes
- Add `djangorestframework` in backend dependencies
- Add `charliermarsh.ruff` to recommend VS Code extensions
- Configure the ruff formatter VS Code extensions 

### Reference 
Django REST Framework: [link](https://www.django-rest-framework.org/)
Ruff: [link](https://github.com/astral-sh/ruff)

